### PR TITLE
create pickled dir if none; use PORT from env or config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ sudo apt-get install python-dev
 
 pip install pygraphviz
 
-mkdir pickled
-
 nano config.py
 
 Usage example:

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ import logging
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 
+PORT = 8888
 ROOT_XHH_DIR = '/home/apertsev/workspace/hh.sites.main/xhh'
 ROOT_XSL_DIR = ROOT_XHH_DIR + '/xsl'
 RESULTS_DIR = 'results'

--- a/pyxsl/pick.py
+++ b/pyxsl/pick.py
@@ -4,6 +4,9 @@ import os
 import pickle
 import config
 
+if not os.path.exists(config.PICKLE_DIR):
+    os.makedirs(config.PICKLE_DIR)
+
 
 def pickle_data_and_index(data, index):
     with open(config.PICKLE_NAME, 'w') as f:

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import os.path
+import os
 import simplejson
 import logging
 import logging.handlers
@@ -129,8 +129,10 @@ if __name__ == "__main__":
 
     ])
 
-    application.listen(8888)
+    port = os.environ.get('PORT', config.PORT)
+    application.listen(port)
     io_loop = tornado.ioloop.IOLoop.instance()
+    logging.getLogger(name='appLogger').info('instance started at http://localhost:{}'.format(port))
 
     tornado.autoreload.start(io_loop, 1000)
     io_loop.start()


### PR DESCRIPTION
Now you can specify `PORT` variable as env variable, or it will fallback to variable defined at `config.py`
`PICKLE_DIR` will now be automatically created upon first start if no directory with the same name is present 